### PR TITLE
Bugfix/tokens retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.5.2 - 2019-03-16
+
+### Fix
+
+-   tokens retrieval: If retrieved tokens are expired, refresh them and now **wait for the refresh request to finish** and then fetch auth. user. In other words, user won't have to login into app so often as now.
+
 ## 3.5.1 - 2019-03-05
 
 ### Updated

--- a/src/sagas/tokens/tryToRetrieveTokens.js
+++ b/src/sagas/tokens/tryToRetrieveTokens.js
@@ -1,6 +1,6 @@
 import { take, race, put, call, select } from 'redux-saga/effects';
 
-import { AUTH_LOGIN_SUCCESS } from '../../actionType';
+import { AUTH_LOGIN_SUCCESS, AUTH_REFRESH_TOKEN_SUCCESS, AUTH_REFRESH_TOKEN_FAILURE } from '../../actionType';
 import {
     refreshTokens,
     setTokens,
@@ -45,10 +45,14 @@ function* tokensRetrieval() {
 
     if (isAnyTokenExpired(tokens)) {
         yield put(refreshTokens(tokens));
+        // 'retrieveTokensResolve' action must be dispatched when tokens has been refreshed
+        // otherwise authorizable HOC will render <Firewall/> which is wrong.
+        yield take([AUTH_REFRESH_TOKEN_SUCCESS, AUTH_REFRESH_TOKEN_FAILURE]);
     } else {
         yield put(setTokens(tokens));
-        yield put(fetchAuthUserRequest());
     }
+
+    yield put(fetchAuthUserRequest());
 
     return true;
 }


### PR DESCRIPTION
### Fix
-   tokens retrieval: If retrieved tokens are expired, refresh them and now **wait for the refresh request to finish** and then fetch auth. user. In other words, user won't have to login into app so often as now.    

- resolves #29 