### PR TITLE
tokens/refreshment: pass refreshed tokens to applyAccessTokenExternal…

### DIFF
--- a/src/modules/tokens/modules/refreshment/sagas/refreshTokens.js
+++ b/src/modules/tokens/modules/refreshment/sagas/refreshTokens.js
@@ -10,15 +10,15 @@ import { refreshTokensSuccess, refreshTokensFailure, types } from '../actions';
 
 function* refreshTokens(action) {
     try {
-        const tokens = yield select(tokensSelector);
+        const tokens = action.payload ? action.payload : yield select(tokensSelector);
 
-        const refreshedTokens = yield config.remoteHandlers.refreshTokens(action.payload || tokens);
+        const refreshedTokens = yield config.remoteHandlers.refreshTokens(tokens);
 
         validateTokens(refreshedTokens);
 
-        yield put(setTokens(refreshedTokens));
+        yield select(tokensSelector);
 
-        yield applyAccessTokenExternally(tokens);
+        yield applyAccessTokenExternally(refreshedTokens);
 
         yield put(refreshTokensSuccess());
     } catch (e) {


### PR DESCRIPTION
Fix fetch auth. user 401 error
- Pass *refreshed tokens* to `applyAccessTokenExternally` instead of the old ones.