### PR TITLE
🐛 Fix opening connection to index db

### DIFF
--- a/src/config/storageDrivers/indexedDB.js
+++ b/src/config/storageDrivers/indexedDB.js
@@ -22,7 +22,7 @@ const idbConfig = {
 
 async function openDB() {
     try {
-        const open = globalEnv.indexedDB ? openDBReal(DATABASE_NAME, DATABASE_VERSION, idbConfig) : storageMock;
+        const open = globalEnv.indexedDB ? openDBReal : storageMock;
         const db = await open(DATABASE_NAME, DATABASE_VERSION, idbConfig);
 
         return db;


### PR DESCRIPTION
Old code always throws exception which resulted in fallback to storageMock. This pull request solves it.