### PR TITLE
♻️ Refactor handling thrown errors in sagas

### DIFF
--- a/src/modules/auth-session/sagas/directLogin.js
+++ b/src/modules/auth-session/sagas/directLogin.js
@@ -28,7 +28,7 @@ const handleSetUserWithTokens = function* (action) {
 
         yield put(loginSuccess());
     } catch (e) {
-        config.logger.error(`Failed to set user with tokens: ${e.message}.`);
+        config.logger.error(`Failed to set user with tokens: ${e.toString()}.`);
         yield put(loginFailure(e));
     }
 };

--- a/src/modules/auth-session/sagas/fetchUser.js
+++ b/src/modules/auth-session/sagas/fetchUser.js
@@ -19,8 +19,8 @@ function* fetchUser() {
 
         yield put(loginSuccess());
     } catch (e) {
-        config.logger.error(e);
-        yield put(fetchUserFailure(e.message));
+        config.logger.error(e.toString());
+        yield put(fetchUserFailure(e));
     }
 }
 

--- a/src/modules/auth-session/sagas/login.js
+++ b/src/modules/auth-session/sagas/login.js
@@ -26,8 +26,8 @@ const handleLogin = function* (action) {
 
         yield put(loginSuccess());
     } catch (e) {
-        config.logger.error(`User login failed: ${e.message}`);
-        yield put(loginFailure(e.message));
+        config.logger.error(`User login failed: ${e.toString()}`);
+        yield put(loginFailure(e));
     }
 };
 

--- a/src/modules/auth-session/sagas/logout.js
+++ b/src/modules/auth-session/sagas/logout.js
@@ -21,8 +21,8 @@ function* logout() {
 
         yield put(logoutSuccess());
     } catch (e) {
-        config.logger.error(e);
-        yield put(logoutFailure(e.message));
+        config.logger.error(e.toString());
+        yield put(logoutFailure(e));
     }
 }
 

--- a/src/modules/tokens/modules/refreshment/sagas/refreshTokens.js
+++ b/src/modules/tokens/modules/refreshment/sagas/refreshTokens.js
@@ -22,8 +22,8 @@ function* refreshTokens(action) {
 
         yield put(refreshTokensSuccess());
     } catch (e) {
-        config.logger.error(e);
-        yield put(refreshTokensFailure(e.message));
+        config.logger.error(e.toString());
+        yield put(refreshTokensFailure(e));
         yield put(deleteTokens());
     }
 }


### PR DESCRIPTION
We should be aware that also plain string can be thrown like

```js
throw "This is a plain string error, not an intance of Error"
```

thus the `.message` property doesnt need to be available.

Because of that, it's better to use toString() to log errorand then send whole error to the failure action. Which is also better if the application wants to handle errors by it's type, eg. throwing `GracefulAuthenticationEnd extends Error`.