### PR TITLE
:bug: Fix checking sessionStorage availability

### DIFF
--- a/src/config/storageDrivers/sessionStorage.js
+++ b/src/config/storageDrivers/sessionStorage.js
@@ -8,7 +8,7 @@ const storageMock = {
     getItem: noop,
 };
 
-const storage = globalEnv.sessionStorage || storageMock;
+const storage = 'sessionStorage' in globalEnv || storageMock;
 
 export default Object.freeze({
     set(key, values) {


### PR DESCRIPTION
Executing `window.sessionStorage` causes an error in Chrome anonymous window, this type of storage can't be used there.