### PR TITLE
Feat/no auth user

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -89,9 +89,10 @@ const { saga, reducer } = configure({
 
 #### Handlers
 
-1. `authenticate(credentials: any) => { user: any, tokens: TokensShape }`
+1. `authenticate(credentials: any) => { user?: any, tokens: TokensShape }`
 
-    This method is called when the `loginRequest(credentials)` action is dispatched. The credentials object is passed to `authenticate` method where you handles the authentication and returns object with `user` and `tokens`.
+    - Called when `loginRequest(credentials)` action dispatches.
+    - If `user` isn't returned, `getAuthUser` handler is called.
 
     #### Example
 
@@ -648,9 +649,9 @@ function* mySaga() {
 
 ### <a name="hoc"></a>HOC
 
-#### `authorizable(AuthorizableComponent, Firewall, Loader) => AuthorizedComponent`
+#### ~~`authorizable(AuthorizableComponent, Firewall, Loader) => AuthorizedComponent`~~
 
-> `authorizable` HOC will be deprecated soon. We suggest using `Authenticated` component instead
+> `authorizable` HOC has been deprecated. Use the [`Authenticated`](#authenticated) component instead.
 
 High order component that based on current state of the `auth` reducer renders one of these components:
 

--- a/src/HOC/authorizable.jsx
+++ b/src/HOC/authorizable.jsx
@@ -5,6 +5,10 @@ import Authenticated from '../components/Authenticated';
 
 const MockAppLoader = () => <div>Loading...</div>;
 
+/**
+ * Use `Authenticated` component instead.
+ * @deprecated
+ */
 const withAuthorizable = (AuthorizableComponent, Firewall, Loader = MockAppLoader) => {
     const AuthorizedComponent = props => (
         <Authenticated FallbackComponent={Firewall} Loader={Loader}>
@@ -13,7 +17,7 @@ const withAuthorizable = (AuthorizableComponent, Firewall, Loader = MockAppLoade
     );
 
     // eslint-disable-next-line no-console
-    console.warning('authorizable HOC will be deprecated soon. We suggest using Authenticated component instead.');
+    console.warn('authorizable HOC has been depcreated. Use Authenticated component instead.');
 
     AuthorizedComponent.displayName = `Authorizable(${getDisplayName(AuthorizableComponent)})`;
 

--- a/src/config/storageDrivers/sessionStorage.js
+++ b/src/config/storageDrivers/sessionStorage.js
@@ -8,7 +8,7 @@ const storageMock = {
     getItem: noop,
 };
 
-const storage = 'sessionStorage' in globalEnv || storageMock;
+const storage = 'sessionStorage' in globalEnv ? globalEnv.sessionStorage : storageMock;
 
 export default Object.freeze({
     set(key, values) {


### PR DESCRIPTION
__What__
If `authenticate` handle returns `user: null`, `getAuthUser` handler is called. 

__Why__
This useful when there's a special EP for fetching auth user and the app shouldn't be auth. before the user is available.

__Also__
Mark `authorizable` HOC as deprecated since we have the `Authenticated` component now.
