### PR TITLE
Fix resolving of getAccessToken 

### DIFF
--- a/src/services/sagas/getAccessToken.js
+++ b/src/services/sagas/getAccessToken.js
@@ -4,7 +4,6 @@ import { AuthSession, apiKeys } from 'constants/index';
 import { sessionStateSelector, accessTokenSelector, apiSelectorFactory } from 'services/selectors/index';
 import { types } from 'services/actions';
 
-import { types as retrievalTypes } from 'modules/tokens/modules/retrieval';
 import { types as refreshmentTypes } from 'modules/tokens/modules/refreshment';
 
 const retrieveTokensApiSelector = apiSelectorFactory(apiKeys.RETRIEVE_TOKENS);
@@ -16,7 +15,13 @@ function* preSessionResolvement() {
         return null;
     }
 
-    yield take(retrievalTypes.RETRIEVE_TOKENS_RESOLVE);
+    const accessToken = yield select(accessTokenSelector);
+
+    if (accessToken) {
+        return accessToken;
+    }
+
+    yield take(types.SET_TOKENS);
 
     return yield select(accessTokenSelector);
 }


### PR DESCRIPTION
 Resolve `getAccessToken` when `accessToken` is avail. or on `SET_TOKENS` action during tokens retrieval.

__Why?__
Because `RETRIEVE_TOKENS_RESOLVE` is dispatched after auth user has been fetched. But that's too late in some cases.

Fixes #66