### PR TITLE
🚨  Fix correct Authenticated prop type

### DIFF
--- a/src/components/Authenticated.jsx
+++ b/src/components/Authenticated.jsx
@@ -25,12 +25,15 @@ const Authenticated = ({ children, FallbackComponent, LoaderComponent }) => {
 
 Authenticated.propTypes = {
     children: PropTypes.node.isRequired,
-    FallbackComponent: PropTypes.func.isRequired,
-    LoaderComponent: PropTypes.func,
+    FallbackComponent: PropTypes.elementType,
+    LoaderComponent: PropTypes.elementType,
 };
 
+const Empty = () => null;
+
 Authenticated.defaultProps = {
-    LoaderComponent: () => null,
+    FallbackComponent: Empty,
+    LoaderComponent: Empty,
 };
 
 export default Authenticated;


### PR DESCRIPTION
Fixes a case when correct `FallbackComponent` type was passed, but there was a invalid prop type console warning.