### PR TITLE
:bug: set upper limit for access token timeout refreshment

### DIFF
--- a/src/modules/tokens/modules/refreshment/sagas/utils/tokenExpiration.js
+++ b/src/modules/tokens/modules/refreshment/sagas/utils/tokenExpiration.js
@@ -22,6 +22,17 @@ export function validateTimeoutValue(timeout, { minRequiredExpiration, requestDu
             }ms.`,
         );
     }
+
+    /**
+     * The `setTimeout` is using a 32 bit int to store the delay so the max value allowed would be `2147483648 === 0b10000000000000000000000000000000`.
+     * If the delay value is bigger, the setTimeout fires immediately.
+     * https://stackoverflow.com/questions/3468607/why-does-settimeout-break-for-large-millisecond-delay-values
+     */
+    const MAX_ALLOWED_VALUE = 2147483647;
+
+    if (timeout > MAX_ALLOWED_VALUE) {
+        throw new Error(`Timeout for refreshing access token must be <= ${MAX_ALLOWED_VALUE}, received: ${timeout}.`);
+    }
 }
 
 /**


### PR DESCRIPTION
Refreshing access token timeout - throw an error if the upper limit has been exceeded.

Resolves #72