### PR TITLE
:sparkles: Conditional starting of retrieveTokens saga

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,10 @@ This method must be always called exactly once. It returns `saga` and `reducer`.
         // Check if access token is expired when document visibility changes
         // from 'hidden' to 'visibile'. And it's expired, then refresh access token.
         checkTokenExpirationOnTabFocus: true,
+
+        // If false, petrus won't start tokens retrieval saga automatically but it's up to you to call `retrieveTokens` saga.
+        // By calling `retrieveTokens` saga, petrus starts the authentication flow. Either it signs-in user with avail. access token or it won't if the access token is expired and couldn't be refreshed.
+        autoStartTokensRetrieval: true,
     },
 
     // Default value is window.console

--- a/src/index.js
+++ b/src/index.js
@@ -64,3 +64,4 @@ export { entitiesSelector, apiSelector } from './services/selectors';
 export { createExpirationDate } from './modules/oAuth';
 export { StorageDrivers } from './config';
 export { AuthSession as SessionState, FlowType } from './constants';
+export { retrieveTokens } from 'modules/tokens/modules/retrieval';

--- a/src/modules/tokens/configure/index.js
+++ b/src/modules/tokens/configure/index.js
@@ -16,6 +16,7 @@ export const handlers = ({ refreshTokens } = {}) => {
 
 export const options = (customOptions = {}) => ({
     applyAccessTokenExternally: false,
+    autoStartTokensRetrieval: true,
     ...refreshmentConfig.options,
     ...customOptions,
 });

--- a/src/modules/tokens/modules/retrieval/index.js
+++ b/src/modules/tokens/modules/retrieval/index.js
@@ -1,3 +1,3 @@
 export { default as apiReducers } from './reducers/api';
-export { default as saga } from './sagas';
+export { retrieveTokens } from './sagas';
 export { types } from './actions';

--- a/src/modules/tokens/modules/retrieval/sagas/index.js
+++ b/src/modules/tokens/modules/retrieval/sagas/index.js
@@ -1,1 +1,1 @@
-export { default } from './retrieveTokens';
+export { retrieveTokens } from './retrieveTokens';

--- a/src/modules/tokens/modules/retrieval/sagas/retrieveTokens.js
+++ b/src/modules/tokens/modules/retrieval/sagas/retrieveTokens.js
@@ -68,7 +68,7 @@ function* tokensRetrieval() {
     return fetchUserResultAction.type === authSessionTypes.FETCH_USER_SUCCESS;
 }
 
-export default function* tryToRetrieveTokens() {
+export function* retrieveTokens() {
     yield put(retrieveTokensRequest());
 
     const tokensRetrieved = yield call(tokensRetrieval);

--- a/src/modules/tokens/services/sagas/index.js
+++ b/src/modules/tokens/services/sagas/index.js
@@ -1,9 +1,11 @@
 import { all } from 'redux-saga/effects';
 
+import { config } from 'config';
+
 import { saga as refreshment } from 'modules/tokens/modules/refreshment';
-import { saga as retrieval } from 'modules/tokens/modules/retrieval';
+import { retrieveTokens } from 'modules/tokens/modules/retrieval';
 import { saga as storage } from 'modules/tokens/modules/storage';
 
 export default function* () {
-    yield all([storage(), refreshment(), retrieval()]);
+    yield all([storage(), refreshment(), config.tokens.autoStartTokensRetrieval && retrieveTokens()].filter(Boolean));
 }


### PR DESCRIPTION
- Make starting `retrieveTokens` saga conditional based on `autoStartTokensRetrieval` option.
- `autoStartTokensRetrieval` is true by default, thus it isn't a breaking change.
- So if `autoStartTokensRetrieval: false`, then it's up to you to call `retrieveTokens`: `import { retrieveTokens } from '@ackee/petrus'` whenever you need. 

----

Resolves #78 