### PR TITLE
♻️ Extend PetrusError with type and originalError props

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,10 +15,40 @@ export const config = {
     initialized: false,
 } as PetrusConfig;
 
-export class PetrusError extends Error {
-    constructor(message: string) {
+export enum PetrusErrorType {
+    CONFIGURE_METHOD_CAN_BE_CALLED_ONLY_ONCE,
+
+    INVALID_AUTHENTICATE_HANDLER,
+    INVALID_GET_AUTH_USER_HANDLER,
+    INVALID_REFRESH_TOKENS_HANDLER,
+    INVALID_OAUTH_CONFIG,
+    INVALID_TIMEOUT,
+    INVALID_TOKENS,
+
+    UNAVAILABLE_TOKENS,
+    UNAVAILABLE_AUTH_USER,
+
+    GET_AUTH_USER_FAILURE,
+    LOGIN_FAILURE,
+    LOGOUT_FAILURE,
+    REFRESH_TOKENS_FAILURE,
+    DIRECT_LOGIN_FAILURE,
+    GET_OAUTH_TOKENS_FAILURE,
+    SET_ACCESS_TOKEN_REFRESHMENT_TIMER_FAILURE,
+    CLEAR_TOKENS_FAILURE,
+    SET_TOKENS_FAILURE,
+    SET_TOKENS_PERSISTENCE_FAILURE,
+}
+
+export class PetrusError<OriginalError extends Error = Error> extends Error {
+    originalError: OriginalError | undefined;
+    type: PetrusErrorType;
+
+    constructor(type: PetrusErrorType, message: string, originalError?: OriginalError) {
         super(message);
         this.name = 'PetrusError';
+        this.type = type;
+        this.originalError = originalError;
     }
 }
 

--- a/src/configure/index.ts
+++ b/src/configure/index.ts
@@ -1,4 +1,4 @@
-import { PetrusError, config, storageDrivers } from 'config';
+import { PetrusError, config, storageDrivers, PetrusErrorType } from 'config';
 
 import { configure as oAuth } from 'modules/oAuth';
 import { configure as authSession } from 'modules/auth-session';
@@ -88,7 +88,10 @@ import type { AppRootState, PetrusCustomConfig } from 'types';
  */
 export function configure(customConfig: PetrusCustomConfig) {
     if (config.initialized) {
-        throw new PetrusError(`'configure' method can be called only once.`);
+        throw new PetrusError(
+            PetrusErrorType.CONFIGURE_METHOD_CAN_BE_CALLED_ONLY_ONCE,
+            `'configure' method can be called only once.`,
+        );
     }
 
     const oAuthConfig = oAuth(customConfig.oAuth);

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export {
     tokensPersistenceSelector,
 } from './services/selectors';
 export { createExpirationDate } from './modules/oAuth';
-export { storageDrivers, isPetrusError } from './config';
+export { storageDrivers, isPetrusError, PetrusErrorType } from './config';
 export * from './constants';
 export { retrieveTokens } from 'modules/tokens/modules/retrieval';
 

--- a/src/modules/auth-session/configure/index.ts
+++ b/src/modules/auth-session/configure/index.ts
@@ -1,4 +1,4 @@
-import { PetrusError } from 'config';
+import { PetrusError, PetrusErrorType } from 'config';
 import { isFn } from 'services/utils';
 
 import { TokensPersistence } from 'modules/tokens';
@@ -12,13 +12,17 @@ export const handlers = (
     authenticate: PetrusConfig['handlers']['authenticate'];
 } => {
     if (!oAuthEnabled && !isFn(authenticate)) {
-        throw new PetrusError(`'authenticate' is not a function: Received argument: '${authenticate}'.`);
+        throw new PetrusError(
+            PetrusErrorType.INVALID_AUTHENTICATE_HANDLER,
+            `'authenticate' is not a function: Received argument: '${authenticate}'.`,
+        );
     }
 
     const { LOCAL, NONE } = TokensPersistence;
 
     if (tokensPersistence === LOCAL && !isFn(getAuthUser)) {
         throw new PetrusError(
+            PetrusErrorType.INVALID_GET_AUTH_USER_HANDLER,
             // eslint-disable-next-line max-len
             `'getAuthUser' is not a function: '${getAuthUser}'. Tokens persistence is set to '${LOCAL}'. Change tokens persistence to '${NONE}' or provide function for fetching authorized user.`,
         );

--- a/src/modules/auth-session/sagas/logout.ts
+++ b/src/modules/auth-session/sagas/logout.ts
@@ -1,6 +1,6 @@
 import { takeLeading, put } from 'redux-saga/effects';
 
-import { config } from 'config';
+import { config, PetrusError, PetrusErrorType } from 'config';
 import { deleteTokens } from 'services/actions';
 import { logout } from '../actions';
 
@@ -27,8 +27,8 @@ function* logoutHandler() {
 
         yield put(logout.success());
     } catch (e) {
-        const error = e as Error;
-        config.logger.error(error.toString());
+        const error = new PetrusError(PetrusErrorType.LOGOUT_FAILURE, 'Failed to logout.', e as Error);
+        config.logger.error(error);
         yield put(logout.failure(error));
     }
 }

--- a/src/modules/oAuth/configure/validateOAuth.ts
+++ b/src/modules/oAuth/configure/validateOAuth.ts
@@ -1,4 +1,4 @@
-import { PetrusError } from 'config';
+import { PetrusError, PetrusErrorType } from 'config';
 import { isFn, isEmptyStr } from 'services/utils';
 import type { PetrusConfig } from 'types';
 
@@ -15,6 +15,7 @@ export function validateOAuth(oAuth: PetrusConfig['oAuth']) {
 
     if (isEmptyStr(redirectPathname)) {
         throw new PetrusError(
+            PetrusErrorType.INVALID_OAUTH_CONFIG,
             `'config.oAuth.redirectPathname' must be non-empty string. Received value: '${redirectPathname}'.`,
         );
     }
@@ -29,6 +30,7 @@ export function validateOAuth(oAuth: PetrusConfig['oAuth']) {
     }).forEach(([fnName, fnValue]) => {
         if (!isFn(fnValue)) {
             throw new PetrusError(
+                PetrusErrorType.INVALID_OAUTH_CONFIG,
                 `'config.oAuth.${fnName}' must be a function, not a '${typeof fnValue}', received value: '${fnValue}'.`,
             );
         }

--- a/src/modules/oAuth/sagas/getOAuthTokens.ts
+++ b/src/modules/oAuth/sagas/getOAuthTokens.ts
@@ -1,4 +1,4 @@
-import { config } from 'config';
+import { config, isPetrusError, PetrusError, PetrusErrorType } from 'config';
 import type { PetrusOAuth, PetrusTokens } from 'types';
 
 function* getOAuthTokens() {
@@ -35,7 +35,13 @@ export function* getMaybeOAuthTokens() {
     try {
         return yield* getOAuthTokens();
     } catch (e) {
-        config.logger.error(e);
+        if (isPetrusError(e)) {
+            config.logger.error(e);
+        } else {
+            config.logger.error(
+                new PetrusError(PetrusErrorType.GET_OAUTH_TOKENS_FAILURE, `Failed to get oAuth tokens.`, e as Error),
+            );
+        }
         return null;
     }
 }

--- a/src/modules/tokens/configure/index.ts
+++ b/src/modules/tokens/configure/index.ts
@@ -1,4 +1,4 @@
-import { PetrusError } from 'config';
+import { PetrusError, PetrusErrorType } from 'config';
 import { isFn } from 'services/utils';
 import type { PetrusConfig, PetrusCustomConfig } from 'types';
 
@@ -10,7 +10,10 @@ export const handlers = ({
     refreshTokens: PetrusConfig['handlers']['refreshTokens'];
 } => {
     if (!isFn(refreshTokens)) {
-        throw new PetrusError(`'refreshTokens' is not a function: Received argument: ${refreshTokens}.`);
+        throw new PetrusError(
+            PetrusErrorType.INVALID_REFRESH_TOKENS_HANDLER,
+            `'refreshTokens' is not a function: Received argument: ${refreshTokens}.`,
+        );
     }
 
     return {

--- a/src/modules/tokens/modules/refreshment/sagas/setTokens.ts
+++ b/src/modules/tokens/modules/refreshment/sagas/setTokens.ts
@@ -1,6 +1,6 @@
 import { takeEvery, put } from 'redux-saga/effects';
 
-import { config } from 'config';
+import { config, PetrusError, PetrusErrorType } from 'config';
 import { refreshTokens } from '../actions';
 
 import { setTimer, cancelTimer } from './tokensExpirationTimer';
@@ -18,7 +18,12 @@ export default function* setTokensHandler() {
                 // eslint-disable-next-line max-len
                 const minRequired = `Minimal required access token expiration is ${min}ms (at ${minDate.toISOString()}).`;
                 const cantSet = `Expiration at ${expiration} it too low.`;
-                config.logger.error(`${minRequired}\n${cantSet}`);
+                config.logger.error(
+                    new PetrusError(
+                        PetrusErrorType.SET_ACCESS_TOKEN_REFRESHMENT_TIMER_FAILURE,
+                        `${minRequired}\n${cantSet}`,
+                    ),
+                );
                 return;
             }
 

--- a/src/modules/tokens/modules/refreshment/sagas/tokensExpirationTimer.ts
+++ b/src/modules/tokens/modules/refreshment/sagas/tokensExpirationTimer.ts
@@ -1,8 +1,6 @@
 import type { Task } from 'redux-saga';
 import { cancel, fork, call, delay } from 'redux-saga/effects';
 
-import { config } from 'config';
-
 import { validateTimeoutValue, calcTimeoutValue } from './utils';
 import type { DefaultFn } from 'types';
 
@@ -26,7 +24,7 @@ function* startTimer(timeout: number, callbackSaga: DefaultFn) {
 export function* setTimer(expiration: string, callbackSaga: DefaultFn) {
     const timeout = calcTimeoutValue(expiration);
 
-    validateTimeoutValue(timeout, config.tokens);
+    validateTimeoutValue(timeout);
 
     timerTask = yield fork(startTimer, timeout, callbackSaga);
 }

--- a/src/modules/tokens/modules/storage/sagas/deleteTokens.ts
+++ b/src/modules/tokens/modules/storage/sagas/deleteTokens.ts
@@ -1,4 +1,4 @@
-import { config } from 'config';
+import { config, PetrusError, PetrusErrorType } from 'config';
 import { takeEvery } from 'redux-saga/effects';
 
 import { deleteTokens } from 'services/actions';
@@ -10,7 +10,9 @@ export default function* deleteTokensHandler() {
             // TODO: extend DELETE_TOKENS to async action type
             yield* clearTokens();
         } catch (e) {
-            config.logger.error(e);
+            config.logger.error(
+                new PetrusError(PetrusErrorType.CLEAR_TOKENS_FAILURE, 'Failed to clear tokens.', e as Error),
+            );
         }
     });
 }

--- a/src/modules/tokens/modules/storage/sagas/setTokens.ts
+++ b/src/modules/tokens/modules/storage/sagas/setTokens.ts
@@ -1,4 +1,4 @@
-import { config } from 'config';
+import { config, PetrusError, PetrusErrorType } from 'config';
 import { takeEvery } from 'redux-saga/effects';
 
 import { setTokens } from 'services/actions';
@@ -10,7 +10,9 @@ export default function* setTokensHandler() {
             // TODO:extend SET_TOKENS to async action type
             yield* storeTokens(action.payload);
         } catch (e) {
-            config.logger.error(e);
+            config.logger.error(
+                new PetrusError(PetrusErrorType.SET_TOKENS_FAILURE, 'Failed to store tokens.', e as Error),
+            );
         }
     });
 }

--- a/src/modules/tokens/modules/storage/sagas/setTokensPersistence.ts
+++ b/src/modules/tokens/modules/storage/sagas/setTokensPersistence.ts
@@ -1,6 +1,6 @@
 import { takeLatest } from 'redux-saga/effects';
 
-import { config } from 'config';
+import { config, isPetrusError, PetrusError, PetrusErrorType } from 'config';
 import { TokensPersistence } from 'modules/tokens/modules/storage/constants';
 
 import { setTokensPersistence } from '../actions';
@@ -34,7 +34,17 @@ export default function* setTokensPersistenceHandler() {
         try {
             yield applyTokensPersistence(action.payload);
         } catch (e) {
-            config.logger.error(e);
+            if (isPetrusError(e)) {
+                config.logger.error(e);
+            } else {
+                config.logger.error(
+                    new PetrusError(
+                        PetrusErrorType.SET_TOKENS_PERSISTENCE_FAILURE,
+                        'Failed to set tokens persistence.',
+                        e as Error,
+                    ),
+                );
+            }
         }
     });
 }

--- a/src/services/utils/validateTokens.ts
+++ b/src/services/utils/validateTokens.ts
@@ -1,4 +1,4 @@
-import { PetrusError } from 'config';
+import { PetrusError, PetrusErrorType } from 'config';
 
 function isPlainObject<T extends Record<string, any>>(o: T) {
     return typeof o === 'object' && o.constructor === Object;
@@ -6,13 +6,19 @@ function isPlainObject<T extends Record<string, any>>(o: T) {
 
 export default function validateTokens<T extends Record<string, any>>(tokens?: T): void | never {
     if (!tokens || !isPlainObject(tokens)) {
-        throw new PetrusError(`'tokens' must be an object including 'accessToken' property.`);
+        throw new PetrusError(
+            PetrusErrorType.INVALID_TOKENS,
+            `'tokens' must be an object including 'accessToken' property.`,
+        );
     }
 
     const { accessToken } = tokens;
 
     if (!isPlainObject(accessToken) || !accessToken.token) {
-        throw new PetrusError(`'tokens.accessToken' must be an object including at least 'token' property.`);
+        throw new PetrusError(
+            PetrusErrorType.INVALID_TOKENS,
+            `'tokens.accessToken' must be an object including at least 'token' property.`,
+        );
     }
 }
 


### PR DESCRIPTION
Usage example
```ts
import { configure, isPetrusError, PetrusErrorType } from '@ackee/petrus';


const sentryAcceptedErrors = new Set([PetrusErrorType.GET_AUTH_USER_FAILURE]);

configure({
   logger: {
      error(error) {

          if (isPetrusError(error) && sentryAcceptedErrors.has(error.type)) {
             // logout to Sentry
             console.error(error.message, error.type, error.originalError);
         }
       }
      // ...
   },
   // ...
})
```