### PR TITLE
🐛 Fix incorrect parameters order of IndexedDB put

### DIFF
--- a/src/config/storageDrivers/indexedDB.ts
+++ b/src/config/storageDrivers/indexedDB.ts
@@ -30,7 +30,10 @@ const db = openDB();
 
 async function accessDB(operation: 'get' | 'put' | 'delete', key: string, value?: any) {
     try {
-        return (await db)[operation](DATABASE_STORE_NAME, key, value);
+        if (operation === 'put') {
+            return (await db)[operation](DATABASE_STORE_NAME, value, key);
+        }
+        return (await db)[operation](DATABASE_STORE_NAME, key);
     } catch (e) {
         const ignoresError = 'A mutation operation was attempted on a database that did not allow mutations.';
 


### PR DESCRIPTION
When fixing the #115, we changed the order of the parameters of the put function and used `.put(DATABASE_STORE_NAME, key, value)` instead of `.put(DATABASE_STORE_NAME, value, key)`. That caused the following error: `"Failed to execute 'put' on 'IDBObjectStore': The parameter is not a valid key."`